### PR TITLE
Added 'selected' as action target for items in the Select Bar.

### DIFF
--- a/src/main/java/net/bdew/wurm/action/ActionMod.java
+++ b/src/main/java/net/bdew/wurm/action/ActionMod.java
@@ -73,7 +73,7 @@ public class ActionMod implements WurmMod, Initable, PreInitable {
                     return true;
                 }
             }
-            hud.consoleOutput("Usage: act <id> {hover|body|tile}");
+            hud.consoleOutput("Usage: act <id> {hover|body|tile|selected}");
             return true;
         }
         return false;

--- a/src/main/java/net/bdew/wurm/action/ActionMod.java
+++ b/src/main/java/net/bdew/wurm/action/ActionMod.java
@@ -1,6 +1,7 @@
 package net.bdew.wurm.action;
 
 import com.wurmonline.client.console.WurmConsole;
+import com.wurmonline.client.renderer.PickableUnit;
 import com.wurmonline.client.renderer.gui.HeadsUpDisplay;
 import com.wurmonline.shared.constants.PlayerAction;
 import javassist.ClassPool;
@@ -60,6 +61,15 @@ public class ActionMod implements WurmMod, Initable, PreInitable {
                     return true;
                 } else if (data[2].equals("tile")) {
                     hud.getWorld().sendLocalAction(new PlayerAction(id, PlayerAction.ANYTHING));
+                    return true;
+                } else if (data[2].equals("selected")) {
+                    try {
+                        PickableUnit p = Reflect.getSelectedUnit(hud.getSelectBar());
+                        if(p != null)
+                            hud.sendAction(new PlayerAction(id, PlayerAction.ANYTHING), p.getId());
+                    } catch (ReflectiveOperationException e) {
+                        throw new RuntimeException(e);
+                    }
                     return true;
                 }
             }

--- a/src/main/java/net/bdew/wurm/action/Reflect.java
+++ b/src/main/java/net/bdew/wurm/action/Reflect.java
@@ -1,9 +1,11 @@
 package net.bdew.wurm.action;
 
 import com.wurmonline.client.game.inventory.InventoryMetaItem;
+import com.wurmonline.client.renderer.PickableUnit;
 import com.wurmonline.client.renderer.gui.HeadsUpDisplay;
 import com.wurmonline.client.renderer.gui.PaperDollInventory;
 import com.wurmonline.client.renderer.gui.PaperDollSlot;
+import com.wurmonline.client.renderer.gui.SelectBar;
 
 import java.lang.reflect.Field;
 
@@ -14,6 +16,9 @@ public class Reflect {
 
     // PaperDollInventory
     static private Field fldBodyItem;
+    
+    // Selected Unit
+    static private Field fldSelectedUnit;
 
 
     static public void setup() throws ReflectiveOperationException {
@@ -22,6 +27,9 @@ public class Reflect {
 
         fldBodyItem = PaperDollInventory.class.getDeclaredField("bodyItem");
         fldBodyItem.setAccessible(true);
+        
+        fldSelectedUnit = SelectBar.class.getDeclaredField("selectedUnit");
+        fldSelectedUnit.setAccessible(true);
     }
 
     public static PaperDollInventory getPaperdollInventory(HeadsUpDisplay hud) throws ReflectiveOperationException {
@@ -30,5 +38,9 @@ public class Reflect {
 
     public static InventoryMetaItem getBodyItem(PaperDollInventory pd) throws ReflectiveOperationException {
         return ((PaperDollSlot) fldBodyItem.get(pd)).getItem();
+    }
+    
+    public static PickableUnit getSelectedUnit(SelectBar s) throws ReflectiveOperationException {
+        return (PickableUnit) fldSelectedUnit.get(s);
     }
 }


### PR DESCRIPTION
Added the 'selected' option, allowing you to send an action from the context of the entity in the select bar. For example, click on a tent to place it in your select bar and `bind o "act 3 selected"`, now pressing "o" will open the tent if you are in range.

This may seem redundant as you can bind select bar buttons, but not all actions are mapped to select bar buttons!
